### PR TITLE
chore: do not renovate go.mod

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -41,20 +41,7 @@
       depNameTemplate: 'dagger/dagger',
     },
   ],
-  packageRules: [
-    {
-      matchDatasources: [
-        'go',
-      ],
-      matchUpdateTypes: [
-        'minor',
-        'patch',
-        'digest',
-      ],
-      groupName: 'all non-major go dependencies',
-      matchPackageNames: [
-        '*',
-      ],
-    },
-  ],
+  gomod: {
+    enabled: false,
+  },
 }


### PR DESCRIPTION
Disable go.mod renovate updates. Every module there is managed by `dagger develop`, we do not need automated PRs for them.

Closes: #76 