### PR TITLE
fix(crd-ref-docs): wrong renderer default

### DIFF
--- a/crd-ref-docs/main.go
+++ b/crd-ref-docs/main.go
@@ -65,7 +65,7 @@ func (m *CrdRefDocs) Generate(
 // The path of the template director, relative to the source directory.
 	templatesDir string,
 // +optional
-// +default="asciidoc"
+// +default="asciidoctor"
 // The renderer for the generated documentation.
 	renderer Renderer,
 // +optional


### PR DESCRIPTION
The default was set as asciidoc, but the right value in the enum is asciidoctor. This breaks on dagger 0.18.11+.