### PR TITLE
fix(uncommitted): pin setuptools version used

### DIFF
--- a/uncommitted/dagger/main.go
+++ b/uncommitted/dagger/main.go
@@ -19,7 +19,7 @@ func New(
 	return &Uncommitted{
 		Ctr: dag.Container().From(Image).
 			WithExec([]string{"apk", "add", "git"}).
-			WithExec([]string{"pip", "install", "setuptools", "check-uncommitted-git-changes"}),
+			WithExec([]string{"pip", "install", "setuptools==81.0.0", "check-uncommitted-git-changes"}),
 	}
 }
 


### PR DESCRIPTION
The check-uncommitted-git-changes doesn't work on setuptools >= 82.0.0.